### PR TITLE
chore: Add .editorconfig and .gitattributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,41 @@
+* text=auto eol=lf
+
+# Source
+*.ts        text eol=lf
+*.tsx       text eol=lf
+*.js        text eol=lf
+*.jsx       text eol=lf
+*.mjs       text eol=lf
+*.cjs       text eol=lf
+*.json      text eol=lf
+*.css       text eol=lf
+*.scss      text eol=lf
+*.html      text eol=lf
+*.md        text eol=lf
+*.yml       text eol=lf
+*.yaml      text eol=lf
+*.sql       text eol=lf
+*.sh        text eol=lf
+
+# Lockfiles — keep LF, skip diff noise
+package-lock.json   text eol=lf -diff
+yarn.lock           text eol=lf -diff
+pnpm-lock.yaml      text eol=lf -diff
+
+# Binary assets
+*.png       binary
+*.jpg       binary
+*.jpeg      binary
+*.gif       binary
+*.ico       binary
+*.webp      binary
+*.avif      binary
+*.pdf       binary
+*.woff      binary
+*.woff2     binary
+*.ttf       binary
+*.otf       binary
+*.eot       binary
+*.mp4       binary
+*.mov       binary
+*.zip       binary


### PR DESCRIPTION
## Summary
- Add `.editorconfig` — UTF-8, LF, 2-space indent, trim trailing whitespace, final newline (Markdown exempt from trim so hard line breaks survive).
- Add `.gitattributes` — enforce LF for source/config/text files, mark lockfiles as `-diff` to cut review noise, and flag common image/font/media/archive types as binary.

Establishes a whitespace + line-ending baseline to eliminate avoidable diff churn across editors and contributors.

Closes #10

## Test plan
- [ ] Verify new files land at repo root and are tracked by git
- [ ] Editors with EditorConfig support pick up the indent/EOL/charset settings
- [ ] `git check-attr -a package-lock.json` shows `-diff` applied
- [ ] `git check-attr -a public/*.png` (or similar) reports `binary`