### PR TITLE
chore: Add Claude Code permissions allowlist (#8)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,36 @@
+  {
+    "permissions": {
+      "allow": [
+        "Bash(npm run:*)",
+        "Bash(npm ls:*)",
+        "Bash(npm view:*)",
+        "Bash(npm outdated:*)",
+        "Bash(npx tsc:*)",
+        "Bash(npx biome:*)",
+        "Bash(npx shadcn:*)",
+        "Bash(gh issue:*)",
+        "Bash(gh pr:*)",
+        "Bash(gh api:*)",
+        "Bash(gh repo view:*)",
+        "Bash(gh release view:*)",
+        "Bash(gh auth status:*)",
+        "Bash(awk:*)",
+        "Bash(jq:*)",
+        "Bash(python3:*)",
+        "Bash(supabase status:*)",
+        "Bash(supabase db diff:*)",
+        "Bash(supabase db lint:*)",
+        "Bash(supabase migration list:*)",
+        "Bash(supabase projects list:*)",
+        "Bash(supabase functions list:*)",
+        "Bash(supabase link:*)",
+        "Bash(git status:*)",
+        "Bash(git log:*)",
+        "Bash(git diff:*)",
+        "Bash(git show:*)",
+        "Bash(git branch:*)",
+        "Bash(git rev-parse:*)",
+        "Bash(git remote -v)"
+      ]
+    }
+  }

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ next-env.d.ts
 
 # supabase local temp state
 /supabase/.temp/
+
+# claude code — commit the shared allowlist (overrides any global ignore)
+!.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,10 @@ npm run lint
 npm run build
 ```
 
+## Claude Code Permissions
+
+`.claude/settings.local.json` is committed as the shared Claude Code allowlist for this repo. It pre-approves safe, repeatable commands (`npm run …`, `npx tsc …`, `gh issue|pr|api …`, `jq`, `awk`, `python3`, Supabase read commands, and git inspection commands) so Claude Code does not prompt on every call. Add new entries there — not in personal overrides — when you find yourself approving the same safe command repeatedly.
+
 ## Stack Reference
 
 - Next.js 16 (App Router) + React 19 + TypeScript 5, with React Compiler enabled (`reactCompiler: true` in `next.config.ts`)


### PR DESCRIPTION
## Summary
- Commit `.claude/settings.local.json` as the shared Claude Code allowlist so prompts stop firing on every `npm run`, `npx tsc`, `gh issue|pr|api`, `jq`, `awk`, `python3`, Supabase read command, and git inspection command.
- Negate the global gitignore for this file in the project `.gitignore` so it stays tracked.
- Document the allowlist in `CLAUDE.md` under a new *Claude Code Permissions* section.

Closes #8.

## Test plan
- [ ] Confirm `.claude/settings.local.json` is tracked (`git ls-files .claude/`).
- [ ] Start a fresh Claude Code session and verify `npm run lint`, `npx tsc --noEmit`, and `gh issue list` run without permission prompts.