### PR TITLE
chore: Add npm run verify script as pre-push / CI gate

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,36 +1,36 @@
-  {
-    "permissions": {
-      "allow": [
-        "Bash(npm run:*)",
-        "Bash(npm ls:*)",
-        "Bash(npm view:*)",
-        "Bash(npm outdated:*)",
-        "Bash(npx tsc:*)",
-        "Bash(npx biome:*)",
-        "Bash(npx shadcn:*)",
-        "Bash(gh issue:*)",
-        "Bash(gh pr:*)",
-        "Bash(gh api:*)",
-        "Bash(gh repo view:*)",
-        "Bash(gh release view:*)",
-        "Bash(gh auth status:*)",
-        "Bash(awk:*)",
-        "Bash(jq:*)",
-        "Bash(python3:*)",
-        "Bash(supabase status:*)",
-        "Bash(supabase db diff:*)",
-        "Bash(supabase db lint:*)",
-        "Bash(supabase migration list:*)",
-        "Bash(supabase projects list:*)",
-        "Bash(supabase functions list:*)",
-        "Bash(supabase link:*)",
-        "Bash(git status:*)",
-        "Bash(git log:*)",
-        "Bash(git diff:*)",
-        "Bash(git show:*)",
-        "Bash(git branch:*)",
-        "Bash(git rev-parse:*)",
-        "Bash(git remote -v)"
-      ]
-    }
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run:*)",
+      "Bash(npm ls:*)",
+      "Bash(npm view:*)",
+      "Bash(npm outdated:*)",
+      "Bash(npx tsc:*)",
+      "Bash(npx biome:*)",
+      "Bash(npx shadcn:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh api:*)",
+      "Bash(gh repo view:*)",
+      "Bash(gh release view:*)",
+      "Bash(gh auth status:*)",
+      "Bash(awk:*)",
+      "Bash(jq:*)",
+      "Bash(python3:*)",
+      "Bash(supabase status:*)",
+      "Bash(supabase db diff:*)",
+      "Bash(supabase db lint:*)",
+      "Bash(supabase migration list:*)",
+      "Bash(supabase projects list:*)",
+      "Bash(supabase functions list:*)",
+      "Bash(supabase link:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git remote -v)"
+    ]
   }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,12 +27,10 @@ There is no test runner wired up in this repo yet.
 
 ## Validation Before Handoff
 
-Run all three and report any failures:
+Run `npm run verify` (lint + typecheck + build) and report any failures:
 
 ```bash
-npx tsc --noEmit
-npm run lint
-npm run build
+npm run verify
 ```
 
 ## Claude Code Permissions

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "biome check",
     "format": "biome format --write",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "verify": "npm run lint && npm run typecheck && npm run build"
   },
   "dependencies": {
     "@supabase/ssr": "^0.9.0",


### PR DESCRIPTION
Closes #3.

## Summary
- Add `verify` script to `package.json` that chains lint + typecheck + build
- Replace the three-command validation list in `CLAUDE.md` with `npm run verify`
- Reformat `.claude/settings.local.json` to satisfy biome (so the new gate passes cleanly)

## Test plan
- [x] `npm run verify` exits 0 locally
- [ ] CI workflow (#4) wires up to `npm run verify`