### PR TITLE
chore: Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,12 @@ jobs:
   e2e-tests:
     name: E2E tests (Playwright)
     runs-on: ubuntu-latest
+    env:
+      # Placeholder Supabase env so hasSupabaseEnv() returns true at build
+      # and runtime. Public-shell tests don't hit Supabase — auth flows that
+      # do would need real credentials via repo secrets.
+      NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: placeholder-publishable-key
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: 22.20.0
+
+jobs:
+  verify:
+    name: Verify (lint + typecheck + build)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run verify
+
+  unit-tests:
+    name: Unit tests (Vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm test
+
+  e2e-tests:
+    name: E2E tests (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run test:e2e:install
+
+      - run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 14
+
+      - name: Upload Playwright test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: test-results
+          retention-days: 14


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` running three parallel jobs on Node 22.20.0: `verify` (lint + typecheck + build), `unit-tests` (Vitest), and `e2e-tests` (Playwright).
- Trigger on push to `main` and PRs targeting `main`. Concurrency keyed by `github.ref` with `cancel-in-progress` to drop superseded runs.
- On E2E failure, upload `playwright-report/` and `test-results/` as artifacts with 14-day retention.

Closes #4

## Test plan
- [ ] Open this PR and confirm all three jobs (verify, unit-tests, e2e-tests) queue and run
- [ ] Confirm `verify` passes (lint + typecheck + build)
- [ ] Confirm `unit-tests` passes
- [ ] Confirm `e2e-tests` passes
- [ ] Push a subsequent commit and confirm the prior in-flight run is cancelled