### PR TITLE
chore: Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- What changed and why. 1–3 sentences is usually enough. -->
+
+## Changes
+
+<!-- File-level notes on non-obvious edits. Skip trivial files. -->
+
+- `path/to/file.ts` — …
+
+## Validation
+
+- [ ] `npm run verify` (lint + typecheck + build)
+- [ ] `npm test` (Vitest)
+- [ ] `npm run test:e2e` (Playwright)
+- [ ] Manually exercised the affected UI / flow
+
+## Screenshots / recordings
+
+<!-- Required for UI changes. Delete if not applicable. -->
+
+## Related
+
+<!-- Closes #N, or a link to the Linear / GitHub issue this PR addresses. -->
+
+Closes #


### PR DESCRIPTION
## Summary
- Add `.github/pull_request_template.md` so every PR opens with consistent Summary, Changes, Validation, Screenshots, and Related sections.
- Validation checklist covers the three CI gates (`npm run verify`, `npm test`, `npm run test:e2e`) plus a manual UI exercise item.

## Changes
- `.github/pull_request_template.md` — new file; GitHub auto-populates the PR description from it.

## Validation
- [x] Template renders on PR creation (this PR uses it)
- [ ] Confirm checklist items match the scripts in `package.json`

## Related
Closes #11